### PR TITLE
FIX: CLI help needs to be strings not tuples (#646)

### DIFF
--- a/imap_processing/cli.py
+++ b/imap_processing/cli.py
@@ -91,11 +91,11 @@ def _parse_args():
         '--version "v001"'
         '--dependency "['
         '   {"instrument": "mag",'
-        '   "data_level": "l0"',
-        '   "descriptor": "sci"',
-        '   "version": "v001"',
-        '   "start_date": "20231212"',
-        '}]" --upload-to-sdc"',
+        '   "data_level": "l0",'
+        '   "descriptor": "sci",'
+        '   "version": "v001",'
+        '   "start_date": "20231212"'
+        '}]" --upload-to-sdc"'
     )
     instrument_help = (
         "The instrument to process. Acceptable values are: "


### PR DESCRIPTION
The commas need to be inside the strings not outside for the help text to render in the CLI.

# Change Summary

## Overview
<!--Add a list or paragraph giving an overview of your changes-->

## New Dependencies
<!--List any new dependencies introduced by these changes-->

## New Files
<!--List each new file and add bullets to describe the purpose/function of the new file.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
code in the file is serving-->
- new file 1
   - description of new file 1's purpose

## Deleted Files
<!--List each deleted file and add one or more bullets with the rationale for why the file is being deleted-->
- deleted file 1
   - explanation for why file was deleted

## Updated Files
<!--List each updated file and add bullets to describe the purpose/function of the updates.
This should be high level, but enough detail for the reviewer to understand what purpose(s) the
updated code in the file is serving-->
- updated file 1
   - description of change 1 in file 1
   - description of change 2 in file 2
- updated file 2
   - descipriton of change 1 in file 2

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
